### PR TITLE
add personalized "For You" feed and 24-hour article filter

### DIFF
--- a/src/main/java/com/news_aggregator/backend/controller/FeedController.java
+++ b/src/main/java/com/news_aggregator/backend/controller/FeedController.java
@@ -1,0 +1,26 @@
+package com.news_aggregator.backend.controller;
+
+import com.news_aggregator.backend.dto.ArticleDto;
+import com.news_aggregator.backend.service.ArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/articles")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final ArticleService articleService;
+
+    @GetMapping("/feed")
+    public ResponseEntity<List<ArticleDto>> getForYouFeed(@AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(articleService.getForYouFeed(userDetails));
+    }
+}

--- a/src/main/java/com/news_aggregator/backend/service/ArticleService.java
+++ b/src/main/java/com/news_aggregator/backend/service/ArticleService.java
@@ -4,13 +4,19 @@ import com.news_aggregator.backend.dto.ArticleDto;
 import com.news_aggregator.backend.model.Article;
 import com.news_aggregator.backend.model.Category;
 import com.news_aggregator.backend.model.Source;
+import com.news_aggregator.backend.model.User;
 import com.news_aggregator.backend.repository.ArticleRepository;
+import com.news_aggregator.backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,10 +24,12 @@ import java.util.stream.Collectors;
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
+    private final UserRepository userRepository;
 
     @Autowired
-    public ArticleService(ArticleRepository articleRepository) {
+    public ArticleService(ArticleRepository articleRepository, UserRepository userRepository) {
         this.articleRepository = articleRepository;
+        this.userRepository = userRepository;
     }
 
     public List<ArticleDto> getLatestArticles(int limit) {
@@ -41,6 +49,36 @@ public class ArticleService {
                 .and(ArticleSpecification.hasCategories(categoryIds))
                 .and(ArticleSpecification.hasSources(sourceIds))
                 .and(ArticleSpecification.hasDate(date));
+
+        List<Article> articles = articleRepository.findAll(spec, Sort.by(Sort.Direction.DESC, "publishedAt"));
+
+        return articles.stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public List<ArticleDto> getForYouFeed(UserDetails userDetails) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        List<Long> preferredCategoryIds = user.getPreferredCategories().stream()
+                .map(Category::getId)
+                .collect(Collectors.toList());
+        List<Long> preferredSourceIds = user.getPreferredSources().stream()
+                .map(Source::getId)
+                .collect(Collectors.toList());
+
+        // If user has no preferences, return an empty list
+        if (preferredCategoryIds.isEmpty() && preferredSourceIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        OffsetDateTime twentyFourHoursAgo = OffsetDateTime.now().minus(24, ChronoUnit.HOURS);
+        System.out.println("DEBUG: twentyFourHoursAgo = " + twentyFourHoursAgo);
+
+        Specification<Article> spec = Specification.where(ArticleSpecification.hasCategories(preferredCategoryIds))
+                .and(ArticleSpecification.hasSources(preferredSourceIds))
+                .and(ArticleSpecification.isWithinLast24Hours());
 
         List<Article> articles = articleRepository.findAll(spec, Sort.by(Sort.Direction.DESC, "publishedAt"));
 

--- a/src/main/java/com/news_aggregator/backend/service/ArticleSpecification.java
+++ b/src/main/java/com/news_aggregator/backend/service/ArticleSpecification.java
@@ -7,6 +7,8 @@ import jakarta.persistence.criteria.Join;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 public class ArticleSpecification {
@@ -56,6 +58,17 @@ public class ArticleSpecification {
             return criteriaBuilder.equal(
                     criteriaBuilder.function("DATE", LocalDate.class, root.get("publishedAt")),
                     date
+            );
+        };
+    }
+
+    public static Specification<Article> isWithinLast24Hours() {
+        return (root, query, criteriaBuilder) -> {
+            OffsetDateTime now = OffsetDateTime.now();
+            OffsetDateTime twentyFourHoursAgo = now.minus(24, ChronoUnit.HOURS);
+            return criteriaBuilder.and(
+                    criteriaBuilder.greaterThanOrEqualTo(root.get("publishedAt"), twentyFourHoursAgo),
+                    criteriaBuilder.lessThanOrEqualTo(root.get("publishedAt"), now)
             );
         };
     }


### PR DESCRIPTION
- Added `/api/articles/feed` endpoint to fetch articles based on user preferences.
- Updated ArticleService to filter articles from preferred categories/sources within the last 24 hours.
- Added `isWithinLast24Hours()` specification in ArticleSpecification.
- Supports empty list if user has no preferences.