### PR TITLE
feat: Add unified pagination support for articles and feeds

### DIFF
--- a/src/main/java/com/news_aggregator/backend/controller/ArticleController.java
+++ b/src/main/java/com/news_aggregator/backend/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package com.news_aggregator.backend.controller;
 
 import com.news_aggregator.backend.dto.ArticleDto;
+import com.news_aggregator.backend.dto.PagedResponse;
 import com.news_aggregator.backend.service.ArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -27,12 +28,16 @@ public class ArticleController {
     }
 
     @GetMapping(value = "/all", produces = "application/json")
-    public ResponseEntity<List<ArticleDto>> getAllArticles(
-            @RequestParam(required = false, name = "category") List<Long> categoryIds,
-            @RequestParam(required = false, name = "source") List<Long> sourceIds,
-            @RequestParam(required = false, name = "search") String keyword,
-            @RequestParam(required = false, name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
-    ) {
-        return ResponseEntity.ok(articleService.getAllArticles(categoryIds, sourceIds, keyword, date));
-    }
+public ResponseEntity<PagedResponse<ArticleDto>> getAllArticles(
+        @RequestParam(required = false, name = "category") List<Long> categoryIds,
+        @RequestParam(required = false, name = "source") List<Long> sourceIds,
+        @RequestParam(required = false, name = "search") String keyword,
+        @RequestParam(required = false, name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size
+) {
+    return ResponseEntity.ok(articleService.getAllArticles(categoryIds, sourceIds, keyword, date, page, size));
+}
+
+    
 }

--- a/src/main/java/com/news_aggregator/backend/controller/FeedController.java
+++ b/src/main/java/com/news_aggregator/backend/controller/FeedController.java
@@ -1,16 +1,13 @@
 package com.news_aggregator.backend.controller;
 
 import com.news_aggregator.backend.dto.ArticleDto;
+import com.news_aggregator.backend.dto.PagedResponse;
 import com.news_aggregator.backend.service.ArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/articles")
@@ -20,7 +17,11 @@ public class FeedController {
     private final ArticleService articleService;
 
     @GetMapping("/feed")
-    public ResponseEntity<List<ArticleDto>> getForYouFeed(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(articleService.getForYouFeed(userDetails));
+    public ResponseEntity<PagedResponse<ArticleDto>> getForYouFeed(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(articleService.getForYouFeed(userDetails, page, size));
     }
 }

--- a/src/main/java/com/news_aggregator/backend/dto/PagedResponse.java
+++ b/src/main/java/com/news_aggregator/backend/dto/PagedResponse.java
@@ -1,0 +1,18 @@
+package com.news_aggregator.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PagedResponse<T> {
+    private List<T> content;       // actual page of results
+    private int currentPage;       // which page are we on
+    private int totalPages;        // total number of pages
+    private long totalElements;    // total articles matching query
+    private int pageSize;          // size per page
+}


### PR DESCRIPTION
### Changes Included
- Added `PagedResponse<T>` DTO for standardized pagination responses.
- Updated ArticleController:
  • `/api/public/articles/all` now supports `page` and `size` parameters.
  • Returns paginated results instead of raw list.
- Updated FeedController:
  • `/api/articles/feed` now returns `PagedResponse<ArticleDto>`.
  • Added `page` and `size` query params for personalized feed.
- Extended ArticleService:
  • Implemented paginated `getAllArticles(...)` with filters.
  • Implemented paginated `getForYouFeed(...)` based on user preferences.
  • Preserved legacy non-paginated methods for backward compatibility.
- Standardized response format for frontend consumption.