### PR TITLE
feat: Add backend pagination and configurable news fetching

### DIFF
--- a/src/main/java/com/news_aggregator/backend/config/NewsScheduler.java
+++ b/src/main/java/com/news_aggregator/backend/config/NewsScheduler.java
@@ -14,12 +14,12 @@ public class NewsScheduler {
     private final int fetchingEnabled; // 0 or 1
 
     public NewsScheduler(NewsService newsService,
-                         @Value("${fetching.enabled:0}") int fetchingEnabled) {
+                         @Value("${fetching.enabled}") int fetchingEnabled) {
         this.newsService = newsService;
         this.fetchingEnabled = fetchingEnabled;
     }
-    // Run once every 1 hour, only after last run finishes
-    @Scheduled(fixedDelay = 60 * 60 * 1000, initialDelay = 10 * 1000)
+    // Run once every 1 minute, only after last run finishes
+    @Scheduled(fixedDelay = 60 * 1000, initialDelay = 10 * 1000)
     public void fetchDailyNews() {
         if (fetchingEnabled == 0) {
             System.out.println("⏸ Scheduled fetch disabled (fetching.enabled=0).");

--- a/src/main/java/com/news_aggregator/backend/config/StartupNewsFetcher.java
+++ b/src/main/java/com/news_aggregator/backend/config/StartupNewsFetcher.java
@@ -12,7 +12,7 @@ public class StartupNewsFetcher implements CommandLineRunner {
     private final int fetchingEnabled; // 0 or 1
 
     public StartupNewsFetcher(NewsService newsService,
-                              @Value("${fetching.enabled:0}") int fetchingEnabled) {
+                              @Value("${fetching.enabled}") int fetchingEnabled) {
         this.newsService = newsService;
         this.fetchingEnabled = fetchingEnabled;
     }

--- a/src/main/java/com/news_aggregator/backend/controller/ArticleController.java
+++ b/src/main/java/com/news_aggregator/backend/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package com.news_aggregator.backend.controller;
 
 import com.news_aggregator.backend.dto.ArticleDto;
+import com.news_aggregator.backend.dto.PagedResponse;
 import com.news_aggregator.backend.service.ArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -27,12 +28,16 @@ public class ArticleController {
     }
 
     @GetMapping(value = "/all", produces = "application/json")
-    public ResponseEntity<List<ArticleDto>> getAllArticles(
-            @RequestParam(required = false, name = "category") List<Long> categoryIds,
-            @RequestParam(required = false, name = "source") List<Long> sourceIds,
-            @RequestParam(required = false, name = "search") String keyword,
-            @RequestParam(required = false, name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
-    ) {
-        return ResponseEntity.ok(articleService.getAllArticles(categoryIds, sourceIds, keyword, date));
-    }
+public ResponseEntity<PagedResponse<ArticleDto>> getAllArticles(
+        @RequestParam(required = false, name = "category") List<Long> categoryIds,
+        @RequestParam(required = false, name = "source") List<Long> sourceIds,
+        @RequestParam(required = false, name = "search") String keyword,
+        @RequestParam(required = false, name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size
+) {
+    return ResponseEntity.ok(articleService.getAllArticles(categoryIds, sourceIds, keyword, date, page, size));
+}
+
+    
 }

--- a/src/main/java/com/news_aggregator/backend/controller/FeedController.java
+++ b/src/main/java/com/news_aggregator/backend/controller/FeedController.java
@@ -1,16 +1,13 @@
 package com.news_aggregator.backend.controller;
 
 import com.news_aggregator.backend.dto.ArticleDto;
+import com.news_aggregator.backend.dto.PagedResponse;
 import com.news_aggregator.backend.service.ArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/articles")
@@ -20,7 +17,11 @@ public class FeedController {
     private final ArticleService articleService;
 
     @GetMapping("/feed")
-    public ResponseEntity<List<ArticleDto>> getForYouFeed(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(articleService.getForYouFeed(userDetails));
+    public ResponseEntity<PagedResponse<ArticleDto>> getForYouFeed(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(articleService.getForYouFeed(userDetails, page, size));
     }
 }

--- a/src/main/java/com/news_aggregator/backend/dto/PagedResponse.java
+++ b/src/main/java/com/news_aggregator/backend/dto/PagedResponse.java
@@ -1,0 +1,18 @@
+package com.news_aggregator.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PagedResponse<T> {
+    private List<T> content;       // actual page of results
+    private int currentPage;       // which page are we on
+    private int totalPages;        // total number of pages
+    private long totalElements;    // total articles matching query
+    private int pageSize;          // size per page
+}


### PR DESCRIPTION
This PR introduces two major backend improvements: pagination support across article endpoints and environment-driven configuration for scheduled news fetching.

### 1. Pagination Support
- Added generic `PagedResponse<T>` DTO for consistent API responses.
- Updated ArticleController:
  • `/api/public/articles/all` now supports `page` and `size` parameters.
  • Returns paginated results instead of a raw list.
- Updated FeedController:
  • `/api/articles/feed` now returns `PagedResponse<ArticleDto>`.
  • Supports `page` and `size` query params for personalized feeds.
- Extended ArticleService:
  • Implemented paginated `getAllArticles(...)` with filters.
  • Implemented paginated `getForYouFeed(...)` based on user preferences.
  • Preserved legacy non-paginated methods for backward compatibility.

### 2. Configurable News Fetching
- Introduced environment variable `FETCHING_ENABLED` to control startup and scheduled news fetching (0 = disabled, 1 = enabled).
- Updated NewsScheduler:
  • Schedule changed from 1 hour → 1 minute (for testing).
  • Still respects `FETCHING_ENABLED` flag.
- Updated StartupNewsFetcher:
  • Respects same env variable for startup fetch.
- Provides flexible control across environments (e.g., disable in prod, enable in dev).

### Testing
1. Verify `/api/public/articles/all?page=1&size=10` returns a PagedResponse with metadata.
2. Verify `/api/articles/feed?page=1&size=10` returns a PagedResponse for authenticated users.
3. Run with `FETCHING_ENABLED=0` → startup and scheduler should skip fetching.
4. Run with `FETCHING_ENABLED=1` → startup fetch (5 articles) and scheduled fetch (2 articles) should run as expected.
5. Confirm schedule interval is 1 minute (after initial 10s delay).
