### PR TITLE
feat(api): enforce backend pagination + configurable feed hours window

### DIFF
--- a/src/main/java/com/news_aggregator/backend/controller/FeedController.java
+++ b/src/main/java/com/news_aggregator/backend/controller/FeedController.java
@@ -4,6 +4,7 @@ import com.news_aggregator.backend.dto.ArticleDto;
 import com.news_aggregator.backend.dto.PagedResponse;
 import com.news_aggregator.backend.service.ArticleService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,12 +17,19 @@ public class FeedController {
 
     private final ArticleService articleService;
 
+    @Value("${pagination.defaultSize:10}")   // 👈 from env, fallback = 10
+    private int defaultPageSize;
+
+    @Value("${pagination.maxSize:50}")       // 👈 from env, fallback = 50
+    private int maxPageSize;
+
     @GetMapping("/feed")
     public ResponseEntity<PagedResponse<ArticleDto>> getForYouFeed(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(required = false) Integer size
     ) {
-        return ResponseEntity.ok(articleService.getForYouFeed(userDetails, page, size));
+        int pageSize = (size == null || size <= 0) ? defaultPageSize : Math.min(size, maxPageSize);
+        return ResponseEntity.ok(articleService.getForYouFeed(userDetails, page, pageSize));
     }
 }

--- a/src/main/java/com/news_aggregator/backend/service/ArticleSpecification.java
+++ b/src/main/java/com/news_aggregator/backend/service/ArticleSpecification.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 public class ArticleSpecification {
@@ -20,10 +19,8 @@ public class ArticleSpecification {
             }
             String likePattern = "%" + keyword.toLowerCase() + "%";
             return criteriaBuilder.or(
-                    criteriaBuilder.like(criteriaBuilder.lower(root.get("title")),
-                            likePattern),
-                    criteriaBuilder.like(criteriaBuilder.lower(root.get("summary")),
-                            likePattern)
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("title")), likePattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("summary")), likePattern)
             );
         };
     }
@@ -62,12 +59,13 @@ public class ArticleSpecification {
         };
     }
 
-    public static Specification<Article> isWithinLast24Hours() {
+    // ✅ Generic: published within last X hours
+    public static Specification<Article> publishedWithinLastHours(int hours) {
         return (root, query, criteriaBuilder) -> {
             OffsetDateTime now = OffsetDateTime.now();
-            OffsetDateTime twentyFourHoursAgo = now.minus(24, ChronoUnit.HOURS);
+            OffsetDateTime cutoff = now.minusHours(hours);
             return criteriaBuilder.and(
-                    criteriaBuilder.greaterThanOrEqualTo(root.get("publishedAt"), twentyFourHoursAgo),
+                    criteriaBuilder.greaterThanOrEqualTo(root.get("publishedAt"), cutoff),
                     criteriaBuilder.lessThanOrEqualTo(root.get("publishedAt"), now)
             );
         };

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update   # ⚠️ use "validate" in production
+      ddl-auto: none        # use "validate" in prod
       open-in-view: false
     properties:
       hibernate.jdbc.time_zone: UTC
@@ -46,3 +46,14 @@ newsapi:
   language: en
   pageSize: 50
 
+feed:
+  hoursWindow: ${FEED_HOURS_WINDOW}   # default 24 hours if not set
+
+pagination:
+  defaultSize: ${PAGINATION_DEFAULT_SIZE:10}
+  maxSize: ${PAGINATION_MAX_SIZE:50}
+
+articles:
+  latest:
+    defaultLimit: ${LATEST_DEFAULT_LIMIT:9}
+    maxLimit: ${LATEST_MAX_LIMIT:50} # maximum allowed size per page


### PR DESCRIPTION
- Added pagination.defaultSize and pagination.maxSize env-configurable properties
- Enforced server-side page size limits, overriding any FE-provided size
- Introduced feed.hoursWindow property (env FEED_HOURS_WINDOW) to control feed time cutoff
- Removed hardcoded values for page size and feed hours
- Ensured ArticleController and FeedController respect env-based configuration