### PR TITLE
docs(readme): add full environment variable setup instructions for ba…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,29 @@ Configuration is **environment-driven** (`.env` + `application.yml`), keeping se
 
 ## ⚙️ Environment Setup
 
-Run the following command depending on your platform, replacing placeholders (`<VALUE>`) with your actual Neon credentials and settings:
+Run the following command depending on your platform, replacing placeholders "< VALUES >" with your actual configuration values.
+These include database (Neon), server, CORS, pagination, and news fetching settings.
 
 ### macOS / Linux (bash/zsh)
 
 ```bash
-export PGHOST=<your-neon-host>
-export PGPORT=<your-port>
-export PGDATABASE=<your-database>
-export PGUSER=<your-username>
-export PGPASSWORD=<your-password>
+export PGHOST= <your-neon-host>
+export PGPORT= <your-port>
+export PGDATABASE= <your-database>
+export PGUSER= <your-username>
+export PGPASSWORD= <your-password>
 
 export SERVER_PORT=8080
 export CORS_ALLOWED_ORIGINS=http://localhost:5173,https://sustain-insight-front-end.vercel.app
+
+export NEWS_API_KEY= <your-news-api-key>
+export FEED_HOURS_WINDOW= 24
+export PAGINATION_DEFAULT_SIZE= 9
+export PAGINATION_MAX_SIZE= 50
+export LATEST_DEFAULT_LIMIT= 5
+export LATEST_MAX_LIMIT= 20
+export NEWS_FETCHING_ENABLED= false
+
 ```
 
 ### Windows (PowerShell)
@@ -53,6 +63,15 @@ setx PGPASSWORD "<your-password>"
 
 setx SERVER_PORT "8080"
 setx CORS_ALLOWED_ORIGINS "http://localhost:5173,https://sustain-insight-front-end.vercel.app"
+
+setx NEWS_API_KEY "<your-news-api-key>"
+setx FEED_HOURS_WINDOW "24"
+setx PAGINATION_DEFAULT_SIZE "9"
+setx PAGINATION_MAX_SIZE "50"
+setx LATEST_DEFAULT_LIMIT "5"
+setx LATEST_MAX_LIMIT "20"
+setx NEWS_FETCHING_ENABLED "false"
+
 ```
 
 Spring Boot automatically maps these environment variables into `application.yml`.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none        # use "validate" in prod
+      ddl-auto: none        
       open-in-view: false
     properties:
       hibernate.jdbc.time_zone: UTC
@@ -24,7 +24,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info   # ⚠️ safer than "*"
+        include: health,info   
   endpoint:
     health:
       show-details: always
@@ -33,7 +33,6 @@ logging:
   level:
     org.springframework.security: INFO
     org.hibernate.type.descriptor.sql.BasicBinder: INFO
-
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}
@@ -47,16 +46,16 @@ newsapi:
   pageSize: 50
 
 feed:
-  hoursWindow: ${FEED_HOURS_WINDOW}   # default 24 hours if not set
+  hoursWindow: ${FEED_HOURS_WINDOW}   
 
 pagination:
-  defaultSize: ${PAGINATION_DEFAULT_SIZE:10}
-  maxSize: ${PAGINATION_MAX_SIZE:50}
+  defaultSize: ${PAGINATION_DEFAULT_SIZE}
+  maxSize: ${PAGINATION_MAX_SIZE}
 
 articles:
   latest:
-    defaultLimit: ${LATEST_DEFAULT_LIMIT:9}
-    maxLimit: ${LATEST_MAX_LIMIT:50} # maximum allowed size per page
+    defaultLimit: ${LATEST_DEFAULT_LIMIT}
+    maxLimit: ${LATEST_MAX_LIMIT} 
 
 fetching:
   enabled: ${NEWS_FETCHING_ENABLED}


### PR DESCRIPTION
docs(readme): add full environment variable setup instructions for backend  

- Updated README with platform-specific (bash/zsh, PowerShell) export commands  
- Documented all required environment variables including DB (Neon), server, CORS, News API, feed, pagination, and fetching flags  

chore(config): externalize configuration in application.yml  

- Replaced hardcoded values with env-based placeholders  
- Added support for NEWS_API_KEY, FEED_HOURS_WINDOW, pagination, latest article limits, and NEWS_FETCHING_ENABLED  
- Ensured consistency between application.yml and documented README variables  
